### PR TITLE
remove "library(gridExtra)"

### DIFF
--- a/load-extra-functions.R
+++ b/load-extra-functions.R
@@ -3,7 +3,7 @@ library(ggplot2)
 library(phyloseq)
 library(reshape2)
 library(ape)
-library(gridExtra)
+#library(gridExtra)
 
 scripts <- c("graphical_methods.R",
              "tree_methods.R",

--- a/test/test.R
+++ b/test/test.R
@@ -3,7 +3,7 @@ library(phyloseq)
 library(reshape2)
 library(ape)
 library(dplyr)
-library(gridExtra)
+#library(gridExtra)
 library(plotly)
 
 source("R/graphical_methods.R")


### PR DESCRIPTION
gridExtra package is loaded (and not present in DESCRIPTION) but it looks like to be never used.